### PR TITLE
Add build.yaml parsing test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,3 +3,14 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install PyYAML
+      - name: Run tests
+        run: python -m unittest discover -v

--- a/tests/test_build_yaml.py
+++ b/tests/test_build_yaml.py
@@ -1,0 +1,13 @@
+import pathlib
+import unittest
+import yaml
+
+class TestBuildYaml(unittest.TestCase):
+    def test_parse_build_yaml(self):
+        build_file = pathlib.Path(__file__).resolve().parents[1] / "build.yaml"
+        with open(build_file, 'r') as f:
+            data = yaml.safe_load(f)
+        self.assertIsNotNone(data)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a simple unittest that loads `build.yaml`
- run the tests in CI via GitHub Actions

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684d8666ce208330a9b6cb7e018f6a6d